### PR TITLE
Directly export parse method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@ nameparts
 =========
 [![Build Status](https://travis-ci.org/Ghary/nameparts.svg)](https://travis-ci.org/Ghary/nameparts)
 
-nameparts is port to NodeJS module from a Python module written by [James Polera](https://github.com/polera) to
-address a problem splitting full names into individual parts (first, middle, last, etc.).
+nameparts is a code port from a Python project to NodeJS. The original Python module written by
+[James Polera](https://github.com/polera) to address the problem of having to split full names into
+individual parts (first, middle, last, etc.).
 
-You can use it like this:
+To use this module:
 ```
 > var NameParts = require('nameparts');
 > var parts = NameParts.parse('Bruce Wayne a/k/a Batman');

--- a/nameparts.js
+++ b/nameparts.js
@@ -153,6 +153,10 @@
             // Has supplemental info?
             if (output.hasSupplementalInfo !== true) {
                 output.hasSupplementalInfo = SUPPLEMENTAL_INFO.indexOf(namePieceUpperCase) !== -1;
+
+                if (output.hasSupplementalInfo === true) {
+                    namePieces.splice(namePiecesIndex, 1);
+                }
             }
 
             // Increment index
@@ -165,11 +169,10 @@
 
         // The rest
         if (namePieces.length > 1) {
-            output.middleName = namePieces[0];
-            output.lastName = namePieces[1];
-        } else {
-            output.lastName = namePieces.join(' ');
+            output.middleName = namePieces.splice(0, namePieces.length - 1).join(' ');
         }
+
+        output.lastName = namePieces[0];
 
         // Return parsed information
         return output;

--- a/nameparts.js
+++ b/nameparts.js
@@ -95,7 +95,7 @@
 
             // Has LN Prefix?
             if (output.hasLnPrefix !== true) {
-                output.hasLnPrefix = LNPREFIXES.indexOf(namePieceUpperCase) !== -1;
+                output.hasLnPrefix = LNPREFIXES.indexOf(namePieceUpperCase) !== -1 && namePiecesIndex !== 0;
                 if (output.hasLnPrefix === true) {
                     namePieces[namePiecesIndex] += ' ' + namePieces[namePiecesIndex + 1];
                     namePieces.splice(namePiecesIndex + 1, 1);

--- a/nameparts.js
+++ b/nameparts.js
@@ -34,9 +34,8 @@
 
     var SUPPLEMENTAL_INFO = ['WIFE OF', 'HUSBAND OF', 'SON OF', 'DAUGHTER OF', 'DECEASED'];
 
-    function NameParts() {}
 
-    NameParts.prototype.parse = function(name) {
+    function parse (name) {
         var modifiedName = name;
         var output = {
             fullName: name,
@@ -178,9 +177,11 @@
 
     // Export
     if (typeof module !== 'undefined' && module.exports) {
-        module.exports = new NameParts();
+        module.exports = parse;
+        module.exports.parse = parse;
+    } else {
+        // Save to either 'window' or 'global'
+        root.NameParts = parse;
+        root.NameParts.parse = parse;
     }
-
-    // Save to either 'window' or 'global'
-    root.NameParts = new NameParts();
 })(this);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nameparts",
   "description": "Splits full names into individual parts (first, middle, last, etc.)",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "http://github.com/Ghary/nameparts.git"

--- a/spec/NamePartsSpec.js
+++ b/spec/NamePartsSpec.js
@@ -16,11 +16,11 @@ describe('NameParts.js', function() {
 
     describe('parse()', function() {
         it('should parse a simple name', function() {
-            var nameParts = NameParts.parse('John Jacob');
+            var nameParts = NameParts.parse('Ben Jacob');
 
             // Parse results
-            expect(nameParts.fullName).toBe('John Jacob');
-            expect(nameParts.firstName).toBe('John');
+            expect(nameParts.fullName).toBe('Ben Jacob');
+            expect(nameParts.firstName).toBe('Ben');
             expect(nameParts.lastName).toBe('Jacob');
 
             // Members not used for this result

--- a/spec/NamePartsSpec.js
+++ b/spec/NamePartsSpec.js
@@ -325,14 +325,12 @@ describe('NameParts.js', function() {
             expect(nameParts.hasLnPrefix).toBe(false);
         });
 
-        /*
-        xit('should parse a name with multiple middle names', function() {
+        it('should parse a name with multiple middle names', function() {
             var nameParts = NameParts.parse('George Herbert Walker Bush');
-            assert.equal(nameParts.firstName, 'George');
-            assert.equal(nameParts.middleName, 'Herbert Walker');
-            assert.equal(nameParts.lastName, 'Bush');
+            expect(nameParts.firstName).toBe('George');
+            expect(nameParts.middleName).toBe('Herbert Walker');
+            expect(nameParts.lastName).toBe('Bush');
         });
-        */
 
         /*
         xit('should parse a name with extraneous information', function() {

--- a/spec/NamePartsSpec.js
+++ b/spec/NamePartsSpec.js
@@ -7,7 +7,7 @@ describe('NameParts.js', function() {
 
     it('should load', function() {
         expect(NameParts).toBeDefined();
-        expect(typeof NameParts).toBe('object');
+        expect(typeof NameParts).toBe('function');
     });
 
     it('should have all expected members', function() {

--- a/spec/NamePartsSpec.js
+++ b/spec/NamePartsSpec.js
@@ -16,12 +16,34 @@ describe('NameParts.js', function() {
 
     describe('parse()', function() {
         it('should parse a simple name', function() {
-            var nameParts = NameParts.parse('Ben Jacob');
+            var nameParts = NameParts.parse('John Jacob');
 
             // Parse results
-            expect(nameParts.fullName).toBe('Ben Jacob');
-            expect(nameParts.firstName).toBe('Ben');
+            expect(nameParts.fullName).toBe('John Jacob');
+            expect(nameParts.firstName).toBe('John');
             expect(nameParts.lastName).toBe('Jacob');
+
+            // Members not used for this result
+            expect(nameParts.salutation).toBeNull();
+            expect(nameParts.middleName).toBeNull();
+            expect(nameParts.generation).toBeNull();
+            expect(nameParts.suffix).toBeNull();
+            expect(nameParts.aliases).toBeNull();
+
+            // Flags
+            expect(nameParts.hasCorporateEntity).toBe(false);
+            expect(nameParts.hasNonName).toBe(false);
+            expect(nameParts.hasLnPrefix).toBe(false);
+            expect(nameParts.hasSupplementalInfo).toBe(false);
+        });
+
+        it('should parse a simple name, whose first name matches a LN Prefix', function() {
+            var nameParts = NameParts.parse('Ben Franklin');
+
+            // Parse results
+            expect(nameParts.fullName).toBe('Ben Franklin');
+            expect(nameParts.firstName).toBe('Ben');
+            expect(nameParts.lastName).toBe('Franklin');
 
             // Members not used for this result
             expect(nameParts.salutation).toBeNull();


### PR DESCRIPTION
Hi there, thanks so much for porting this—super useful! I made a couple of non-breaking changes that really just allow me to use the module the way I personally prefer (ie. without namespacing). I also did away with the singleton because I didn’t seem necessary. Totally cool if you don’t want to merge this code, but I figured it would be silly not to ask.
