### PR TITLE
Don’t falsely identify last name prefixes

### DIFF
--- a/nameparts.js
+++ b/nameparts.js
@@ -96,7 +96,7 @@
 
             // Has LN Prefix?
             if (output.hasLnPrefix !== true) {
-                output.hasLnPrefix = LNPREFIXES.indexOf(namePieceUpperCase) !== -1;
+                output.hasLnPrefix = LNPREFIXES.indexOf(namePieceUpperCase) !== -1 && namePiecesIndex !== 0;
                 if (output.hasLnPrefix === true) {
                     namePieces[namePiecesIndex] += ' ' + namePieces[namePiecesIndex + 1];
                     namePieces.splice(namePiecesIndex + 1, 1);

--- a/spec/NamePartsSpec.js
+++ b/spec/NamePartsSpec.js
@@ -16,11 +16,11 @@ describe('NameParts.js', function() {
 
     describe('parse()', function() {
         it('should parse a simple name', function() {
-            var nameParts = NameParts.parse('John Jacob');
+            var nameParts = NameParts.parse('Ben Jacob');
 
             // Parse results
-            expect(nameParts.fullName).toBe('John Jacob');
-            expect(nameParts.firstName).toBe('John');
+            expect(nameParts.fullName).toBe('Ben Jacob');
+            expect(nameParts.firstName).toBe('Ben');
             expect(nameParts.lastName).toBe('Jacob');
 
             // Members not used for this result


### PR DESCRIPTION
This fixes an issue where people named “Ben” weren’t be parsed correctly.